### PR TITLE
Hive

### DIFF
--- a/docs/source/hive.rst
+++ b/docs/source/hive.rst
@@ -1,0 +1,94 @@
+Hive Metastore
+==============
+
+The Hive metastore relates SQL metadata to files on the Hadoop File System
+(HDFS_).  It is similar to a SQL database in that it contains information about
+SQL tables but dissimilar in that data isn't stored in Hive but remains
+ordinary files on HDFS.
+
+Odo interacts with Hive mostly through ``sqlalchemy`` and also with a bit
+of custom code due to its peculiarities.
+
+URIs
+----
+
+Hive uris match exactly SQLAlchemy connection strings with the ``hive://``
+protocol.  Additionally, Impala, another SQL database on HDFS can also connect
+to the same tables.
+::
+
+    hive://hostname
+    hive://user@hostname:port/database-name
+    hive://user@hostname:port/database-name::table-name
+
+    impala://hostname::table-name
+
+Additionally you should probably inspect docs on HDFS_ due to the tight
+integration between the two.
+
+Options
+-------
+
+Hive tables have a few non-standard options on top of normal SQL::
+
+    stored_as - File format on disk like TEXTFILE, PARQUET, ORC
+    path - Absolute path to file location on HDFS
+    external=True - Whether to keep the file external or move it to Hive
+        directory
+
+See `Hive DDL`_ docs for more information.
+
+
+Conversions
+-----------
+
+We commonly load CSV files in to Hive, either from HDFS or from local disk on
+one of the machines that comprise the HDFS cluster::
+
+    HDFS(Directory(CSV)) -> Hive
+    SSH(Directory(CSV)) -> Hive
+    SSH(CSV) -> Hive
+
+Additionally we can use Hive to efficiently migrate this data to new data in a
+different format::
+
+    Hive -> Hive
+
+And as with all SQL systems through SQLAlchemy we can convert a Hive table to a
+Python Iterator, though this is somewhat slow::
+
+    Hive -> Iterator
+
+
+Impala
+------
+
+Impala operates on the same data as Hive, is generally faster, though also has
+a couple of quirks.
+
+While Impala connects to the same metastore it must connect to one of the
+worker nodes, not the same head node to which Hive connects.  After you load
+data in to hive you need to send the ``invalidate metadata`` to Impala.
+
+.. code-block:: Python
+
+   >>> odo('hdfs://hostname::/path/to/data/*.csv', 'hive://hostname::table')
+
+   >>> imp = resource('impala://workernode')
+   >>> imp.connect().execute('invalidate metadata')
+
+This is arguably something that ``odo`` should handle in the future.  After
+this, all tables in Hive are also available to Impala.
+
+You may want to transform your data in to Parquet format for efficient
+querying.  A two minute query on Hive in CSV might take one minute on Hive in
+Parquet and only three seconds in Impala in Parquet.
+
+.. code-block:: Python
+
+   >>> odo('hive://hostname::table', 'hive://hostname::table_parquet',
+   ...     external=False, stored_as='PARQUET')
+
+
+.. _HDFS: hdfs.html
+.. _`Hive DDL`: https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -63,6 +63,7 @@ Formats
    mongo
    ssh
    hdfs
+   hive
    aws
    spark
 

--- a/odo/backends/hdfs.py
+++ b/odo/backends/hdfs.py
@@ -459,6 +459,8 @@ def dialect_of(data, **kwargs):
 
         if data.has_header is None:
             d['has_header'] = sniffer.has_header(text)
+        else:
+            d['has_header'] = data.has_header
 
         d.update(data.dialect)
 

--- a/odo/backends/hdfs.py
+++ b/odo/backends/hdfs.py
@@ -279,9 +279,8 @@ def create_hive_statement(tbl_name, dshape, path=None, table_type='',
         table_type = ''
 
     # Column names and types from datashape
-    ds = dshape or discover(data)
-    assert isinstance(ds.measure, ct.Record)
-    columns = dshape_to_hive(ds)
+    assert isinstance(dshape.measure, ct.Record)
+    columns = dshape_to_hive(dshape)
     column_text = ',\n    '.join('%20s  %s' % tuple(col.split())
                                  for col in columns).lstrip()
 

--- a/odo/backends/sql.py
+++ b/odo/backends/sql.py
@@ -309,6 +309,10 @@ def append_anything_to_sql_Table(t, c, **kwargs):
 def append_anything_to_sql_Table(t, o, **kwargs):
     return append(t, convert(Iterator, o, **kwargs), **kwargs)
 
+@append.register(sa.Table, sa.Table)
+def append_table_to_sql_Table(t, o, **kwargs):
+    s = sa.select([o])
+    return append(t, s, **kwargs)
 
 @append.register(sa.Table, sa.sql.Select)
 def append_select_statement_to_sql_Table(t, o, **kwargs):

--- a/odo/backends/sql.py
+++ b/odo/backends/sql.py
@@ -12,7 +12,7 @@ from datetime import datetime, date
 import datashape
 from toolz import partition_all, keyfilter, first, pluck, memoize, map
 
-from ..utils import keywords
+from ..utils import keywords, ignoring
 from ..convert import convert, ooc_types
 from ..append import append
 from ..resource import resource
@@ -333,22 +333,22 @@ def resource_sql(uri, *args, **kwargs):
     kwargs2 = keyfilter(keywords(sa.create_engine).__contains__, kwargs)
     engine = create_engine(uri, **kwargs2)
     ds = kwargs.get('dshape')
+
+    # we were also given a table name
     if args and isinstance(args[0], str):
         table_name, args = args[0], args[1:]
         metadata = metadata_of_engine(engine)
-        try:
-            metadata.reflect(views=engine.dialect.supports_views)
-        except NotImplementedError:
-            metadata.reflect()
-        if table_name not in metadata.tables:
-            if ds:
-                t = dshape_to_table(table_name, ds, metadata)
-                t.create()
-                return t
-            else:
-                raise ValueError("Table does not exist and no dshape provided")
-        return metadata.tables[table_name]
+        with ignoring(sa.exc.NoSuchTableError):
+            return sa.Table(table_name, metadata, autoload=True,
+                            autoload_with=engine)
+        if ds:
+            t = dshape_to_table(table_name, ds, metadata)
+            t.create()
+            return t
+        else:
+            raise ValueError("Table does not exist and no dshape provided")
 
+    # We were not given a table name
     if ds:
         create_from_datashape(engine, ds)
     return engine

--- a/odo/backends/sql.py
+++ b/odo/backends/sql.py
@@ -311,6 +311,14 @@ def append_anything_to_sql_Table(t, o, **kwargs):
 
 @append.register(sa.Table, sa.Table)
 def append_table_to_sql_Table(t, o, **kwargs):
+    # This condition is an ugly kludge and should be removed once
+    # https://github.com/dropbox/PyHive/issues/15 is resolved
+    if t.bind.name == o.bind.name == 'hive':
+        with t.bind.connect() as conn:
+            conn.execute('INSERT INTO TABLE %s SELECT * FROM %s' %
+                         (t.name, o.name))
+        return t
+
     s = sa.select([o])
     return append(t, s, **kwargs)
 

--- a/odo/backends/tests/test_hdfs.py
+++ b/odo/backends/tests/test_hdfs.py
@@ -15,7 +15,7 @@ from pywebhdfs.webhdfs import PyWebHdfsClient
 import pandas as pd
 import numpy as np
 import uuid
-from odo.backends.hdfs import discover, HDFS, CSV, SSH
+from odo.backends.hdfs import discover, HDFS, CSV, SSH, dialect_of
 from odo.backends.sql import resource
 from odo import into, drop, JSONLines
 from odo.utils import filetext, ignoring, tmpfile
@@ -239,3 +239,20 @@ def test_append_object_to_HDFS_foo():
     with tmpfile_hdfs('json') as fn:
         js = into('hdfs://%s:%s' % (host, fn), df, hdfs=hdfs)
         assert (into(np.ndarray, js) == into(np.ndarray, df)).all()
+
+
+def test_dialect_of():
+    with filetext(accounts_1_csv) as fn:
+        d = dialect_of(CSV(fn))
+        assert d['delimiter'] == ','
+        assert d['has_header'] is True
+
+    with accounts_data() as (directory, (a, b, c)):
+        directory2 = HDFS(Directory(CSV))(directory.path, hdfs=directory.hdfs)
+        d = dialect_of(directory2)
+        assert d['has_header'] is True
+
+        directory2 = HDFS(Directory(CSV))(directory.path, hdfs=directory.hdfs,
+                                          has_header=False)
+        d = dialect_of(directory2)
+        assert d['has_header'] is False

--- a/odo/backends/tests/test_sql.py
+++ b/odo/backends/tests/test_sql.py
@@ -9,7 +9,7 @@ import datashape
 from odo.backends.sql import (dshape_to_table, create_from_datashape,
                                dshape_to_alchemy)
 from odo.utils import tmpfile, raises
-from odo import convert, append, resource, discover, into
+from odo import convert, append, resource, discover, into, odo
 
 
 def test_resource():
@@ -250,6 +250,25 @@ def test_append_from_select(sqlite_file):
     s = into('%s::s' % sqlite_file, raw2)
     t = append(t, s.select())
     result = into(list, t)
+    expected = np.concatenate((raw, raw2)).tolist()
+    assert result == expected
+
+
+def test_append_from_table(sqlite_file):
+    # we can't test in memory here because that creates two independent
+    # databases
+    raw = np.array([(200.0, 'Glenn'),
+                    (314.14, 'Hope'),
+                    (235.43, 'Bob')], dtype=[('amount', 'float64'),
+                                             ('name', 'S5')])
+    raw2 = np.array([(800.0, 'Joe'),
+                     (914.14, 'Alice'),
+                     (1235.43, 'Ratso')], dtype=[('amount', 'float64'),
+                                                 ('name', 'S5')])
+    t = odo(raw, '%s::t' % sqlite_file)
+    s = odo(raw2, '%s::s' % sqlite_file)
+    t = append(t, s)
+    result = odo(t, list)
     expected = np.concatenate((raw, raw2)).tolist()
     assert result == expected
 

--- a/odo/backends/tests/test_sql.py
+++ b/odo/backends/tests/test_sql.py
@@ -254,23 +254,24 @@ def test_append_from_select(sqlite_file):
     assert result == expected
 
 
-def test_append_from_table(sqlite_file):
+def test_append_from_table():
     # we can't test in memory here because that creates two independent
     # databases
-    raw = np.array([(200.0, 'Glenn'),
-                    (314.14, 'Hope'),
-                    (235.43, 'Bob')], dtype=[('amount', 'float64'),
-                                             ('name', 'S5')])
-    raw2 = np.array([(800.0, 'Joe'),
-                     (914.14, 'Alice'),
-                     (1235.43, 'Ratso')], dtype=[('amount', 'float64'),
+    with tmpfile('db') as fn:
+        raw = np.array([(200.0, 'Glenn'),
+                        (314.14, 'Hope'),
+                        (235.43, 'Bob')], dtype=[('amount', 'float64'),
                                                  ('name', 'S5')])
-    t = odo(raw, '%s::t' % sqlite_file)
-    s = odo(raw2, '%s::s' % sqlite_file)
-    t = append(t, s)
-    result = odo(t, list)
-    expected = np.concatenate((raw, raw2)).tolist()
-    assert result == expected
+        raw2 = np.array([(800.0, 'Joe'),
+                         (914.14, 'Alice'),
+                         (1235.43, 'Ratso')], dtype=[('amount', 'float64'),
+                                                     ('name', 'S5')])
+        t = into('sqlite:///%s::t' % fn, raw)
+        s = into('sqlite:///%s::s' % fn, raw2)
+        t = append(t, s)
+        result = odo(t, list)
+        expected = np.concatenate((raw, raw2)).tolist()
+        assert result == expected
 
 
 def test_engine_metadata_caching():


### PR DESCRIPTION
Some updates for Hive

1.  Clean up ssh-hive tests to be less stateful
2.  Handle CSV dialects from directories
3.  Reduce the amount of full-database reflection that happens (this is expensive)
4.  Accept stored_as= and external= kwargs to create non-textfile hive tables

TODO: insert syntax in PyHive doesn't work