### PR TITLE
Make sql<-csv converters robust to absence of sqlite3

### DIFF
--- a/odo/backends/sql_csv.py
+++ b/odo/backends/sql_csv.py
@@ -53,8 +53,9 @@ def execute_copy_sqlite(dialect, engine, statement):
     ps = subprocess.Popen(statement, shell=True,
                           stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     stdout, stderr = ps.communicate()
-    # Windows sometimes doesn't have sqlite3.exe
-    if os.name == 'nt' and (stderr or 'not recognized' in str(stdout)):
+    # If we don't have sqlite3.exe
+    if any(b and a in b.lower() for a in ['not recognized', 'not found']
+                                for b in [stdout, stderr]):
         raise MDNotImplementedError(stderr)
     return stdout
 

--- a/odo/backends/sql_csv.py
+++ b/odo/backends/sql_csv.py
@@ -4,6 +4,7 @@ import os
 import sys
 import re
 import subprocess
+from distutils.spawn import find_executable
 
 import sqlalchemy
 
@@ -50,13 +51,12 @@ def copy_sqlite(dialect, tbl, csv, has_header=None, **kwargs):
 
 @execute_copy.register('sqlite')
 def execute_copy_sqlite(dialect, engine, statement):
+    # If we don't have sqlite3.exe
+    if not find_executable('sqlite3'):
+        raise MDNotImplementedError("Could not find sqlite executable")
     ps = subprocess.Popen(statement, shell=True,
                           stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     stdout, stderr = ps.communicate()
-    # If we don't have sqlite3.exe
-    if any(b and a in b.lower() for a in ['not recognized', 'not found']
-                                for b in [stdout, stderr]):
-        raise MDNotImplementedError(stderr)
     return stdout
 
 


### PR DESCRIPTION
We've done this for Windows in the past.  Now we extend the
solution to other operating systems.

I honestly don't know how to test this well.  Perhaps the Anaconda
build system can help here.

cc @asmeurer