### PR TITLE
Fix export of PyTables function

### DIFF
--- a/odo/__init__.py
+++ b/odo/__init__.py
@@ -33,7 +33,7 @@ with ignoring(ImportError):
 with ignoring(ImportError):
     from .backends.hdfstore import HDFStore
 with ignoring(ImportError):
-    from .backends.pytables import tables
+    from .backends.pytables import PyTables
 with ignoring(ImportError):
     from .backends.dynd import nd
 with ignoring(ImportError):

--- a/odo/backends/pytables.py
+++ b/odo/backends/pytables.py
@@ -5,7 +5,7 @@ from datashape.dispatch import dispatch
 from ..append import append
 from ..convert import convert, ooc_types
 from ..resource import resource
-from ..chunks import chunks, Chunks
+from ..chunks import chunks
 from ..utils import tmpfile
 
 import os


### PR DESCRIPTION
This is so blaze can use the odo version of this, which was lingering around in blaze.