### PR TITLE
BUG: ndarray to df loses field names

### DIFF
--- a/odo/convert.py
+++ b/odo/convert.py
@@ -26,8 +26,8 @@ def dataframe_to_numpy(df, dshape=None, **kwargs):
 
 
 @convert.register(pd.DataFrame, np.ndarray, cost=1.0)
-def numpy_to_dataframe(x, **kwargs):
-    return pd.DataFrame(x)
+def numpy_to_dataframe(x, dshape, **kwargs):
+    return pd.DataFrame(x, columns=getattr(dshape.measure, 'names', None))
 
 
 @convert.register(pd.Series, np.ndarray, cost=1.0)

--- a/odo/tests/test_convert.py
+++ b/odo/tests/test_convert.py
@@ -265,3 +265,12 @@ def test_chunks_of_lists_and_iterators():
     assert convert(list, cl) == [1, 2, 3, 4]
     assert list(convert(Iterator, cl)) == [1, 2, 3, 4]
     assert len(list(convert(chunks(Iterator), cl))) == 2
+
+
+def test_ndarray_to_df_preserves_field_names():
+    ds = dshape('2 * {a: int, b: int}')
+    arr = np.array([[0, 1], [2, 3]])
+    # dshape explicitly sets field names.
+    assert (convert(pd.DataFrame, arr, dshape=ds).columns == ['a', 'b']).all()
+    # no dshape is passed.
+    assert (convert(pd.DataFrame, arr).columns == [0, 1]).all()


### PR DESCRIPTION
I couldn't run a transform on an InteractiveSymbol wrapping an ndarray because it pushed it into a df and lost all the column information

```python
In [1]: es = bz.Data(np.arange(15).reshape(5, 3), fields=list('abc'))

In [2]: bz.transform(es, d=es.a + es.b)
...
KeyError: 'a'
```