### PR TITLE
MAINT: adds copydoc decorator

### DIFF
--- a/docs/source/whatsnew/0.3.4.txt
+++ b/docs/source/whatsnew/0.3.4.txt
@@ -30,3 +30,12 @@ Bug Fixes
   a numpy array to a DataFrame (:issue:`273`).
 * Fix appending into a sql table from chunks not returning the table.
   (:issue:`278`).
+
+Miscellaneous
+-------------
+
+* Adds :func:`~odo.utils.copydoc` function to copy docstrings from one object
+  onto another. This helps with the pattern of explicitly setting the
+  ``__doc__`` attribute to the ``__doc__`` of another function or class. This
+  function can be used as a decorator like: ``@copydoc(FromThisClass)`` or as a
+  function like: ``copydoc(FromThisClass, to_this_function)``. (:issue:`277`).

--- a/odo/backends/aws.py
+++ b/odo/backends/aws.py
@@ -19,7 +19,7 @@ from multipledispatch import MDNotImplementedError
 from .text import TextFile
 
 from ..compatibility import urlparse
-from ..utils import tmpfile, ext, sample, filter_kwargs
+from ..utils import tmpfile, ext, sample, filter_kwargs, copydoc
 
 
 @memoize
@@ -87,12 +87,10 @@ class _S3(object):
                               **filter_kwargs(self.subtype.__init__, kwargs))
 
 
+@memoize
+@copydoc(_S3)
 def S3(cls):
     return type('S3(%s)' % cls.__name__, (_S3, cls), {'subtype': cls})
-
-
-S3.__doc__ = _S3.__doc__
-S3 = memoize(S3)
 
 
 @sample.register((S3(CSV), S3(JSONLines)))

--- a/odo/backends/ssh.py
+++ b/odo/backends/ssh.py
@@ -8,7 +8,7 @@ import re
 import uuid
 
 from ..directory import Directory
-from ..utils import keywords, tmpfile, sample, ignoring
+from ..utils import keywords, tmpfile, sample, ignoring, copydoc
 from ..resource import resource
 from ..append import append
 from ..convert import convert
@@ -78,12 +78,10 @@ class _SSH(object):
         return conn.file(self.path, 'r')
 
 
+@memoize
+@copydoc(_SSH)
 def SSH(cls):
     return type('SSH(%s)' % cls.__name__, (_SSH, cls), {'subtype':  cls})
-
-SSH.__doc__ = _SSH.__doc__
-
-SSH = memoize(SSH)
 
 
 types_by_extension = {'csv': CSV, 'json': JSONLines}

--- a/odo/backends/url.py
+++ b/odo/backends/url.py
@@ -28,7 +28,7 @@ from multipledispatch import MDNotImplementedError
 from .text import TextFile
 
 from ..compatibility import urlparse
-from ..utils import tmpfile, ext, sample
+from ..utils import tmpfile, ext, sample, copydoc
 
 
 class _URL(object):
@@ -70,11 +70,10 @@ class _URL(object):
         self.filename = os.path.basename(urlparse(url).path)
 
 
+@memoize
+@copydoc(_URL)
 def URL(cls):
     return type('URL(%s)' % cls.__name__, (_URL, cls), {'subtype': cls})
-
-URL.__doc__ = _URL.__doc__
-URL = memoize(URL)
 
 
 @sample.register((URL(CSV), URL(JSONLines)))

--- a/odo/chunks.py
+++ b/odo/chunks.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 from toolz import memoize, first
 from datashape import discover, var
-from .utils import cls_name
+from .utils import cls_name, copydoc
 
 
 class Chunks(object):
@@ -36,13 +36,11 @@ class Chunks(object):
             return iter(self.data)
 
 
+@memoize
+@copydoc(Chunks)
 def chunks(cls):
     """ Parametrized Chunks Class """
     return type('chunks(%s)' % cls_name(cls), (Chunks,), {'container': cls})
-
-chunks.__doc__ = Chunks.__doc__
-
-chunks = memoize(chunks)
 
 
 @discover.register(Chunks)

--- a/odo/directory.py
+++ b/odo/directory.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 from glob import glob
 from .chunks import Chunks
 from .resource import resource
+from .utils import copydoc
 from toolz import memoize, first
 from datashape import discover, var
 import os
@@ -33,13 +34,11 @@ class _Directory(Chunks):
                     for fn in sorted(os.listdir(self.path)))
 
 
+@memoize
+@copydoc(_Directory)
 def Directory(cls):
     """ Parametrized DirectoryClass """
     return type('Directory(%s)' % cls.__name__, (_Directory,), {'container': cls})
-
-Directory.__doc__ = Directory.__doc__
-
-Directory = memoize(Directory)
 
 
 re_path_sep = os.path.sep

--- a/odo/regex.py
+++ b/odo/regex.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import re
 
+
 def normalize(r):
     """
 
@@ -12,6 +13,7 @@ def normalize(r):
     '^\d*$'
     """
     return '^' + r.lstrip('^').rstrip('$') + '$'
+
 
 class RegexDispatcher(object):
     """
@@ -44,7 +46,6 @@ class RegexDispatcher(object):
         self.name = name
         self.funcs = dict()
         self.priorities = dict()
-
 
     def add(self, regex, func, priority=10):
         self.funcs[normalize(regex)] = func

--- a/odo/temp.py
+++ b/odo/temp.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import, division, print_function
 from toolz import memoize
 from .drop import drop
+from .utils import copydoc
+
 
 class _Temp(object):
     """ Temporary version of persistent storage
@@ -16,10 +18,8 @@ class _Temp(object):
         drop(self)
 
 
+@memoize
+@copydoc(_Temp)
 def Temp(cls):
     """ Parametrized Chunks Class """
     return type('Temp(%s)' % cls.__name__, (_Temp, cls), {'persistent_type': cls})
-
-Temp.__doc__ = _Temp.__doc__
-
-Temp = memoize(Temp)

--- a/odo/utils.py
+++ b/odo/utils.py
@@ -367,3 +367,23 @@ def filter_kwargs(f, kwargs):
     6
     """
     return keyfilter(keywords(f).__contains__, kwargs)
+
+
+@curry
+def copydoc(from_, to):
+    """Copies the docstring from one function to another.
+
+    Paramaters
+    ----------
+    from_ : any
+        The object to copy the docstring from.
+    to : any
+        The object to copy the docstring to.
+
+    Returns
+    -------
+    to : any
+        ``to`` with the docstring from ``from_``
+    """
+    to.__doc__ = from_.__doc__
+    return to


### PR DESCRIPTION
we have this pattern a lot which prevents us from using decorators as we would normally use them. I also ran into this issue with blaze where I couldn't mutate the `__doc__` of an unbound method in python 2. If this change looks good, I will refactor blaze to use this too.